### PR TITLE
STON-2365 - Fix header / footer options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
 - 2.7
-- 3.2
 - 3.5
 services:
 - docker

--- a/app.py
+++ b/app.py
@@ -23,25 +23,19 @@ def jpg():
 
 
 def handle_request(config):
-    # We are getting the url to generate from a form parameter
-    options = {}
-    options = request.values.getlist('options', type=float)
+    request_data = request.get_json()
+    options = request_data['options']
+
+    print('Options provided: ')
     print(options)
 
-    # Converting post options group to dictionary
-    listname = 'options'
-    options = dict()
-    for key, value in request.form.items():
-        if key[:len(listname)] == listname:
-            options[key[len(listname)+1:-1]] = value
+    if ('url' in request_data):
+        print("URL provided: " + request_data['url'])
+        pdf = pdfkit.from_url(str(request_data['url']), output_path=False, configuration=config, options=options)
 
-    if ('url' in request.form):
-        print("URL provided: " + request.form['url'])
-        pdf = pdfkit.from_url(str(request.form['url']), output_path=False, configuration=config, options=options)
-
-    if ('html' in request.form):
+    if ('html' in request_data):
         print("Html provided")
-        pdf = pdfkit.from_string(unicode(request.form['html']), output_path=False, configuration=config, options=options)
+        pdf = pdfkit.from_string(unicode(request_data['html']), output_path=False, configuration=config, options=options)
 
     # If we are receiving the html contents from a uploaded file
     elif ('content' in request.files):
@@ -75,4 +69,3 @@ def run_server():
 
 if __name__ == "__main__":
     run_server()
-


### PR DESCRIPTION
- the way we were sending these across previously wasn't quite working, as we weren't formatting our POST params as proper form fields, so the nested options were broken
- the simplest solution was for us to send the options across as JSON, as Flask handles JSON by default
- this PR updates the Flask service to retrieve incoming options from the JSON request body
- the code is simplified somewhat now, as `request.get_json()` returns a `dict` object, so all of the code converting the post fields to a dict has been removed